### PR TITLE
Scala/web-plugin bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains templates for Lift projects.
 
 These templates offer a starting point for your Lift-based project.
 
-If you want to start with Scala 2.11.1, use the templates in the scala_211 directory
+If you want to start with Scala 2.11.6, use the templates in the scala_211 directory
 
 ##Getting started.
 
@@ -28,7 +28,7 @@ At your terminal, enter:
 4. `gen-idea`
 
        This will download even more stuff, and it will generate files that Intellij IDEA can read. IntelliJ is one of several IDE's you can use.
-5. `container:start`
+5. `jetty:start`
 6. Your Lift application is now running at [127.0.0.1:8080](http://127.0.0.1:8080)
  
  

--- a/scala_211/README.md
+++ b/scala_211/README.md
@@ -22,5 +22,5 @@
 1. specs2
 2. logback
 3. log back sample xml configuration file (for both, runtime and test)
-4. jetty 8.1
+4. Jetty 9.2.1 (provided by the xsbt-web-plugin)
 5. lift-jquery-module module to bring the latest jQuery plugin

--- a/scala_211/lift_advanced_bs3/build.sbt
+++ b/scala_211/lift_advanced_bs3/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.5"
 
 organization := "net.liftweb"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
 resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositories/snapshots",
                   "staging"       at "https://oss.sonatype.org/content/repositories/staging",

--- a/scala_211/lift_advanced_bs3/build.sbt
+++ b/scala_211/lift_advanced_bs3/build.sbt
@@ -11,8 +11,6 @@ resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositor
                   "releases"      at "https://oss.sonatype.org/content/repositories/releases"
                  )
 
-seq(webSettings :_*)
-
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
@@ -22,13 +20,12 @@ libraryDependencies ++= {
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "fobo_2.6"           % "1.3"     % "compile",
-    "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
-    "org.eclipse.jetty" % "jetty-plus"          % "8.1.7.v20120910"  % "container,test", // For Jetty Config
-    "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
+    "net.liftmodules"   %% "fobo_2.6"           % "1.3"              % "compile",
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",
     "org.specs2"        %% "specs2"             % "2.3.12"           % "test",
-    "com.h2database"    % "h2"                  % "1.3.167"
+    "com.h2database"    % "h2"                  % "1.3.167",
+    "javax.servlet"     % "javax.servlet-api"   % "3.0.1"            % "provided"
   )
 }
 
+enablePlugins(JettyPlugin)

--- a/scala_211/lift_advanced_bs3/project/build.properties
+++ b/scala_211/lift_advanced_bs3/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.1
-
+sbt.version=0.13.8

--- a/scala_211/lift_advanced_bs3/project/plugins.sbt
+++ b/scala_211/lift_advanced_bs3/project/plugins.sbt
@@ -1,5 +1,5 @@
 //Enable the sbt web plugin
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.7.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 
 //Enable the sbt idea plugin
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/scala_211/lift_basic/build.sbt
+++ b/scala_211/lift_basic/build.sbt
@@ -11,8 +11,6 @@ resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositor
                   "releases"      at "https://oss.sonatype.org/content/repositories/releases"
                  )
 
-seq(webSettings :_*)
-
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
@@ -23,12 +21,11 @@ libraryDependencies ++= {
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
     "net.liftmodules"   %% "lift-jquery-module_2.6" % "2.8",
-    "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
-    "org.eclipse.jetty" % "jetty-plus"          % "8.1.7.v20120910"  % "container,test", // For Jetty Config
-    "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",
-    "org.specs2"        %% "specs2"             % "2.3.12"             % "test",
-    "com.h2database"    % "h2"                  % "1.3.167"
+    "org.specs2"        %% "specs2"             % "2.3.12"           % "test",
+    "com.h2database"    % "h2"                  % "1.3.167",
+    "javax.servlet"     % "javax.servlet-api"   % "3.0.1"            % "provided"
   )
 }
 
+enablePlugins(JettyPlugin)

--- a/scala_211/lift_basic/build.sbt
+++ b/scala_211/lift_basic/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.4"
 
 organization := "net.liftweb"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
 resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositories/snapshots",
                   "staging"       at "https://oss.sonatype.org/content/repositories/staging",

--- a/scala_211/lift_basic/project/build.properties
+++ b/scala_211/lift_basic/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.1
-
+sbt.version=0.13.8

--- a/scala_211/lift_basic/project/plugins.sbt
+++ b/scala_211/lift_basic/project/plugins.sbt
@@ -1,5 +1,5 @@
 //Enable the sbt web plugin
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.7.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 
 //Enable the sbt idea plugin
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/scala_211/lift_blank/build.sbt
+++ b/scala_211/lift_blank/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.4"
 
 organization := "net.liftweb"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
 resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositories/snapshots",
                 "releases"        at "https://oss.sonatype.org/content/repositories/releases"

--- a/scala_211/lift_blank/build.sbt
+++ b/scala_211/lift_blank/build.sbt
@@ -10,8 +10,6 @@ resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositor
                 "releases"        at "https://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(webSettings :_*)
-
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
@@ -21,11 +19,10 @@ libraryDependencies ++= {
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftmodules"   %% "lift-jquery-module_2.6" % "2.8",
-    "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
-    "org.eclipse.jetty" % "jetty-plus"          % "8.1.7.v20120910"  % "container,test", // For Jetty Config
-    "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",
-    "org.specs2"        %% "specs2"             % "2.3.12"           % "test"
+    "org.specs2"        %% "specs2"             % "2.3.12"           % "test",
+    "javax.servlet"     % "javax.servlet-api"   % "3.0.1"            % "provided"
   )
 }
 
+enablePlugins(JettyPlugin)

--- a/scala_211/lift_blank/project/build.properties
+++ b/scala_211/lift_blank/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.1
+sbt.version=0.13.8
 

--- a/scala_211/lift_blank/project/plugins.sbt
+++ b/scala_211/lift_blank/project/plugins.sbt
@@ -1,5 +1,5 @@
 //Enable the sbt web plugin
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.7.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 
 //Enable the sbt idea plugin
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/scala_211/lift_json/build.sbt
+++ b/scala_211/lift_json/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.4"
 
 organization := "net.liftweb"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.6"
 
 resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositories/snapshots",
                 "releases"        at "https://oss.sonatype.org/content/repositories/releases"

--- a/scala_211/lift_json/project/build.properties
+++ b/scala_211/lift_json/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.1
-
+sbt.version=0.13.8

--- a/scala_211/lift_json/project/plugins.sbt
+++ b/scala_211/lift_json/project/plugins.sbt
@@ -1,5 +1,5 @@
 //Enable the sbt web plugin
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.7.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 
 //Enable the sbt idea plugin
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/scala_211/lift_mvc/build.sbt
+++ b/scala_211/lift_mvc/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.4"
 
 organization := "net.liftweb"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.6"
 
 resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositories/snapshots",
                 "releases"        at "https://oss.sonatype.org/content/repositories/releases"

--- a/scala_211/lift_mvc/build.sbt
+++ b/scala_211/lift_mvc/build.sbt
@@ -10,8 +10,6 @@ resolvers ++= Seq("snapshots"     at "https://oss.sonatype.org/content/repositor
                 "releases"        at "https://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(webSettings :_*)
-
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
@@ -22,12 +20,11 @@ libraryDependencies ++= {
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
     "net.liftmodules"   %% "lift-jquery-module_2.6" % "2.8",
-    "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
-    "org.eclipse.jetty" % "jetty-plus"          % "8.1.7.v20120910"  % "container,test", // For Jetty Config
-    "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",
     "org.specs2"        %% "specs2"             % "2.3.12"           % "test",
-    "com.h2database"    % "h2"                  % "1.3.167"
+    "com.h2database"    % "h2"                  % "1.3.167",
+    "javax.servlet"     % "javax.servlet-api"   % "3.0.1"            % "provided"
   )
 }
 
+enablePlugins(JettyPlugin)

--- a/scala_211/lift_mvc/project/build.properties
+++ b/scala_211/lift_mvc/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.1
+sbt.version=0.13.8
 

--- a/scala_211/lift_mvc/project/plugins.sbt
+++ b/scala_211/lift_mvc/project/plugins.sbt
@@ -1,5 +1,5 @@
 //Enable the sbt web plugin
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.7.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "2.0.4")
 
 //Enable the sbt idea plugin
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")


### PR DESCRIPTION
This PR:

- Changes the sbt version we boot to 0.13.8.
- Bumps scala to 2.11.6.
- Bumps the xsbt-web-plugin to 2.0.4, which implicitly gives us a newer version of Jetty: 9.2.4. Woohoo.

Of note, the command to start Jetty has changed to `jetty:start` from `container:start` as the xsbt-web-plugin gained tomcat support recently (startable via `tomcat:start` when the `TomcatPlugin` is enabled). I presume the name change was because these two modes can be used in the same sbt configuration.